### PR TITLE
Add apt-utils package to dynamips get and install task

### DIFF
--- a/roles/dynamips/vars/main.yml
+++ b/roles/dynamips/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 packages:
+  - apt-utils
   - libc6-dev-i386
   - gcc-multilib
   - libelf-dev:i386


### PR DESCRIPTION
PR adds `apt-utils` package to `[dynamips : get and install dependencies] `task. #6 